### PR TITLE
Older nodes are mutable and the VDOM patch algorithm efficient

### DIFF
--- a/papito_dom/src/lib.rs
+++ b/papito_dom/src/lib.rs
@@ -16,7 +16,7 @@ mod vtext;
 mod velement;
 mod vlist;
 #[cfg(target_arch = "wasm32")]
-mod vdiff;
+pub mod vdiff;
 #[cfg(target_arch = "wasm32")]
 mod events;
 
@@ -42,6 +42,13 @@ pub fn ev<E, T, F>(listener: E) -> Box<events::DOMEvent> where
     F: FnMut(T) + 'static,
     T: ConcreteEvent + 'static {
     Box::new(listener.into())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn console_log(msg: &str) {
+    js! { @(no_return)
+        console.log(@{ msg });
+    }
 }
 
 #[macro_export]

--- a/papito_dom/src/lib.rs
+++ b/papito_dom/src/lib.rs
@@ -46,13 +46,6 @@ pub fn ev<E, T, F>(listener: E) -> Box<events::DOMEvent> where
     Box::new(listener.into())
 }
 
-#[cfg(target_arch = "wasm32")]
-fn console_log(msg: &str) {
-    js! { @(no_return)
-        console.log(@{ msg });
-    }
-}
-
 #[macro_export]
 macro_rules! h {
     // Creates keyed vnodes

--- a/papito_dom/src/lib.rs
+++ b/papito_dom/src/lib.rs
@@ -1,4 +1,6 @@
 extern crate indexmap;
+#[cfg(target_arch = "wasm32")]
+#[macro_use]
 extern crate stdweb;
 
 use std::borrow::Cow;

--- a/papito_dom/src/vdiff.rs
+++ b/papito_dom/src/vdiff.rs
@@ -15,9 +15,9 @@ pub trait DOMRemove {
 /// Required when re-ordering the `VList` children. Reordering is done by appending the dom node
 /// again in a new order.
 pub trait DOMReorder {
-    fn reorder_append(&self, parent: &Element);
+    fn move_to_last(&self, parent: &Element);
 
-    fn reorder_before(&self, parent: &Element, next: &Node);
+    fn move_before(&self, parent: &Element, next: &Node);
 }
 
 pub trait NextDOMNode {

--- a/papito_dom/src/vdiff.rs
+++ b/papito_dom/src/vdiff.rs
@@ -15,9 +15,9 @@ pub trait DOMRemove {
 /// Required when re-ordering the `VList` children. Reordering is done by appending the dom node
 /// again in a new order.
 pub trait DOMReorder {
-    fn append_child(&self, parent: &Element);
+    fn reorder_append(&self, parent: &Element);
 
-    fn insert_before(&self, parent: &Element, next: &Node);
+    fn reorder_before(&self, parent: &Element, next: &Node);
 }
 
 pub trait NextDOMNode {

--- a/papito_dom/src/vdiff.rs
+++ b/papito_dom/src/vdiff.rs
@@ -4,7 +4,7 @@ use stdweb::web::Node;
 /// Required to update the DOM on the `parent` node. It is also tasked with Diffing along
 /// as it creates patches.
 pub trait DOMPatch<T> {
-    fn patch(&mut self, parent: &Element, old_vnode: Option<&mut T>);
+    fn patch(&mut self, parent: &Element, next: Option<&Node>, old_vnode: Option<&mut T>);
 }
 
 /// Required when removing stale `VNodes`.
@@ -27,9 +27,9 @@ pub trait NextDOMNode {
 impl<T, Q> DOMPatch<T> for Option<Q> where
     Q: DOMPatch<T>,
     T: DOMRemove {
-    fn patch(&mut self, parent: &Element, mut old_vnode: Option<&mut T>) {
+    fn patch(&mut self, parent: &Element, next: Option<&Node>, mut old_vnode: Option<&mut T>) {
         if let Some(ref mut this) = *self {
-            this.patch(parent, old_vnode);
+            this.patch(parent, next, old_vnode);
         } else {
             old_vnode.remove(parent);
         }
@@ -38,9 +38,9 @@ impl<T, Q> DOMPatch<T> for Option<Q> where
 
 impl<T, Q> DOMPatch<Q> for Box<T> where
     T: DOMPatch<Q> {
-    fn patch(&mut self, parent: &Element, old_vnode: Option<&mut Q>) {
+    fn patch(&mut self, parent: &Element, next: Option<&Node>, old_vnode: Option<&mut Q>) {
         let this = &mut **self;
-        this.patch(parent, old_vnode);
+        this.patch(parent, next, old_vnode);
     }
 }
 

--- a/papito_dom/src/vdiff.rs
+++ b/papito_dom/src/vdiff.rs
@@ -1,5 +1,5 @@
 use stdweb::web::Element;
-use stdweb::web::INode;
+use stdweb::web::Node;
 
 /// Required to update the DOM on the `parent` node. It is also tasked with Diffing along
 /// as it creates patches.
@@ -17,7 +17,11 @@ pub trait DOMRemove {
 pub trait DOMReorder {
     fn append_child(&self, parent: &Element);
 
-    fn insert_before<T: INode>(&self, parent: &Element, next: &T);
+    fn insert_before(&self, parent: &Element, next: &Node);
+}
+
+pub trait NextDOMNode {
+    fn next_dom_node(&self) -> Option<Node>;
 }
 
 impl<T, Q> DOMPatch<T> for Option<Q> where

--- a/papito_dom/src/vdiff.rs
+++ b/papito_dom/src/vdiff.rs
@@ -3,12 +3,12 @@ use stdweb::web::Element;
 /// Required to update the DOM on the `parent` node. It is also tasked with Diffing along
 /// as it creates patches.
 pub trait DOMPatch<T> {
-    fn patch(&mut self, parent: &Element, old_vnode: Option<&T>);
+    fn patch(&mut self, parent: &Element, old_vnode: Option<&mut T>);
 }
 
 /// Required when removing stale `VNodes`.
 pub trait DOMRemove {
-    fn remove(&self, parent: &Element);
+    fn remove(&mut self, parent: &Element);
 }
 
 /// Required when re-ordering the `VList` children. Reordering is done by appending the dom node
@@ -20,7 +20,7 @@ pub trait DOMReorder {
 impl<T, Q> DOMPatch<T> for Option<Q> where
     Q: DOMPatch<T>,
     T: DOMRemove {
-    fn patch(&mut self, parent: &Element, old_vnode: Option<&T>) {
+    fn patch(&mut self, parent: &Element, mut old_vnode: Option<&mut T>) {
         if let Some(ref mut this) = *self {
             this.patch(parent, old_vnode);
         } else {
@@ -31,15 +31,15 @@ impl<T, Q> DOMPatch<T> for Option<Q> where
 
 impl<T, Q> DOMPatch<Q> for Box<T> where
     T: DOMPatch<Q> {
-    fn patch(&mut self, parent: &Element, old_vnode: Option<&Q>) {
+    fn patch(&mut self, parent: &Element, old_vnode: Option<&mut Q>) {
         let this = &mut **self;
         this.patch(parent, old_vnode);
     }
 }
 
-impl<'a, T: DOMRemove> DOMRemove for Option<&'a T> {
-    fn remove(&self, parent: &Element) {
-        if let Some(ref inner) = *self {
+impl<'a, T: DOMRemove> DOMRemove for Option<&'a mut T> {
+    fn remove(&mut self, parent: &Element) {
+        if let Some(ref mut inner) = *self {
             inner.remove(parent);
         }
     }

--- a/papito_dom/src/vdiff.rs
+++ b/papito_dom/src/vdiff.rs
@@ -1,4 +1,5 @@
 use stdweb::web::Element;
+use stdweb::web::INode;
 
 /// Required to update the DOM on the `parent` node. It is also tasked with Diffing along
 /// as it creates patches.
@@ -14,7 +15,9 @@ pub trait DOMRemove {
 /// Required when re-ordering the `VList` children. Reordering is done by appending the dom node
 /// again in a new order.
 pub trait DOMReorder {
-    fn reorder(&self, parent: &Element);
+    fn append_child(&self, parent: &Element);
+
+    fn insert_before<T: INode>(&self, parent: &Element, next: &T);
 }
 
 impl<T, Q> DOMPatch<T> for Option<Q> where

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -195,8 +195,9 @@ fn split_into_class_and_attrs(mut attrs: Attributes) -> (Option<ClassString>, Op
 mod wasm {
     use indexmap::IndexMap;
     use stdweb::web::{Element, document, INode, IElement};
-    use vdiff::{DOMPatch, DOMRemove, DOMReorder};
+    use vdiff::{DOMPatch, DOMRemove};
     use super::{VElement, ClassString, Attributes, Events};
+    use vdiff::DOMReorder;
 
     impl DOMPatch<VElement> for VElement {
         fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VElement>) {
@@ -220,12 +221,16 @@ mod wasm {
     }
 
     impl DOMReorder for VElement {
-        fn reorder(&self, parent: &Element) {
-            let dom_ref = self.dom_ref().expect("Cannot re-order previously non-existent element.");
+        fn append_child(&self, parent: &Element) {
+            let dom_ref = self.dom_ref().expect("Cannot append previously non-existent element.");
             parent.append_child(dom_ref);
         }
-    }
 
+        fn insert_before<T: INode>(&self, parent: &Element, next: &T) {
+            parent.insert_before(self.dom_ref().expect("Cannot insert previously non-existent text node."), next)
+                .unwrap();
+        }
+    }
 
     impl DOMRemove for VElement {
         fn remove(&mut self, parent: &Element) {

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -251,9 +251,11 @@ mod wasm {
     }
 
     impl DOMPatch<ClassString> for ClassString {
-        fn patch(&mut self, parent: &Element, _: Option<&mut ClassString>) {
-            parent.set_attribute("class", &self.0)
-                .unwrap();
+        fn patch(&mut self, parent: &Element, old_value: Option<&mut ClassString>) {
+            if Some(&mut *self) != old_value {
+                parent.set_attribute("class", &self.0)
+                    .unwrap();
+            }
         }
     }
 
@@ -270,8 +272,10 @@ mod wasm {
                 .collect::<IndexMap<_, _>>())
                 .unwrap_or(IndexMap::new());
             for (k, v) in self.0.iter() {
-                parent.set_attribute(&k, &v).unwrap();
-                deleted_attrs.swap_remove(&k);
+                let old_attr_val = deleted_attrs.swap_remove(&k);
+                if Some(v) != old_attr_val {
+                    parent.set_attribute(&k, &v).unwrap();
+                }
             }
             for (k, _) in deleted_attrs.iter() {
                 parent.remove_attribute(&k);

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -223,12 +223,12 @@ mod wasm {
     }
 
     impl DOMReorder for VElement {
-        fn append_child(&self, parent: &Element) {
+        fn reorder_append(&self, parent: &Element) {
             let dom_ref = self.dom_ref().expect("Cannot append previously non-existent element.");
             parent.append_child(dom_ref);
         }
 
-        fn insert_before(&self, parent: &Element, next: &Node) {
+        fn reorder_before(&self, parent: &Element, next: &Node) {
             parent.insert_before(self.dom_ref().expect("Cannot insert previously non-existent text node."), next)
                 .unwrap();
         }

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -280,14 +280,18 @@ mod wasm {
     }
 
     impl DOMPatch<Events> for Events {
-        fn patch(&mut self, parent: &Element, old_vnode: Option<&mut Events>) {
-            if let Some(events) = old_vnode {
-                for ev in events.0.iter_mut() {
-                    ev.detach();
-                }
-            }
+        fn patch(&mut self, parent: &Element, mut old_vnode: Option<&mut Events>) {
+            old_vnode.remove(parent);
             for ev in self.0.iter_mut() {
                 ev.attach(parent);
+            }
+        }
+    }
+
+    impl DOMRemove for Events {
+        fn remove(&mut self, _: &Element) {
+            for ev in self.0.iter_mut() {
+                ev.detach();
             }
         }
     }

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -229,14 +229,14 @@ mod wasm {
 
     impl DOMRemove for VElement {
         fn remove(&mut self, parent: &Element) {
+            let dom_ref = self.dom_ref.take()
+                .expect("Cannot remove non-existent element.");
             // Dismember the events
-            self.events.remove(parent);
+            self.events.remove(&dom_ref);
             // Remove child and their events
-            self.child.as_mut().map(|it| &mut **it).remove(parent);
+            self.child.as_mut().map(|it| &mut **it).remove(&dom_ref);
             // Lastly remove self
-            parent.remove_child(&self.dom_ref.take()
-                .expect("Cannot remove non-existent element.")
-            ).unwrap();
+            parent.remove_child(&dom_ref).unwrap();
         }
     }
 

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -198,6 +198,8 @@ mod wasm {
     use vdiff::{DOMPatch, DOMRemove};
     use super::{VElement, ClassString, Attributes, Events};
     use vdiff::DOMReorder;
+    use vdiff::NextDOMNode;
+    use stdweb::web::Node;
 
     impl DOMPatch<VElement> for VElement {
         fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VElement>) {
@@ -226,7 +228,7 @@ mod wasm {
             parent.append_child(dom_ref);
         }
 
-        fn insert_before<T: INode>(&self, parent: &Element, next: &T) {
+        fn insert_before(&self, parent: &Element, next: &Node) {
             parent.insert_before(self.dom_ref().expect("Cannot insert previously non-existent text node."), next)
                 .unwrap();
         }
@@ -311,6 +313,12 @@ mod wasm {
             for ev in self.0.iter_mut() {
                 ev.detach();
             }
+        }
+    }
+
+    impl NextDOMNode for VElement {
+        fn next_dom_node(&self) -> Option<Node> {
+            self.dom_ref.clone().map(|it| it.into())
         }
     }
 }

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -232,7 +232,7 @@ mod wasm {
             // Dismember the events
             self.events.remove(parent);
             // Remove child and their events
-            self.child.remove(parent);
+            self.child.as_mut().map(|it| &mut **it).remove(parent);
             // Lastly remove self
             parent.remove_child(&self.dom_ref.take()
                 .expect("Cannot remove non-existent element.")

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -29,6 +29,7 @@ impl Display for Attributes {
     }
 }
 
+#[cfg(target_arch = "wasm32")]
 #[derive(Debug, Eq, PartialEq)]
 pub struct Events(Vec<Box<DOMEvent>>);
 

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -254,7 +254,7 @@ mod wasm {
         vel.child.patch(&el_node, None, None);
         vel.events.patch(&el_node, None, None);
         if let Some(next) = next {
-            parent.insert_before(&el_node, next);
+            parent.insert_before(&el_node, next).unwrap();
         } else {
             parent.append_child(&el_node);
         }

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -279,13 +279,16 @@ mod wasm {
         }
     }
 
-//    impl DOMPatch for Events {
-//        fn patch(&mut self, parent: &Element, old_vnode: Option<&Events>) {
-//            if let Some(ref events) = old_vnode {
-//                for ev in events.0.iter() {
-//                    ev.rem
-//                }
-//            }
-//        }
-//    }
+    impl DOMPatch<Events> for Events {
+        fn patch(&mut self, parent: &Element, old_vnode: Option<&mut Events>) {
+            if let Some(events) = old_vnode {
+                for ev in events.0.iter_mut() {
+                    ev.detach();
+                }
+            }
+            for ev in self.0.iter_mut() {
+                ev.attach(parent);
+            }
+        }
+    }
 }

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -223,12 +223,12 @@ mod wasm {
     }
 
     impl DOMReorder for VElement {
-        fn reorder_append(&self, parent: &Element) {
+        fn move_to_last(&self, parent: &Element) {
             let dom_ref = self.dom_ref().expect("Cannot append previously non-existent element.");
             parent.append_child(dom_ref);
         }
 
-        fn reorder_before(&self, parent: &Element, next: &Node) {
+        fn move_before(&self, parent: &Element, next: &Node) {
             parent.insert_before(self.dom_ref().expect("Cannot insert previously non-existent text node."), next)
                 .unwrap();
         }

--- a/papito_dom/src/velement.rs
+++ b/papito_dom/src/velement.rs
@@ -226,8 +226,9 @@ mod wasm {
 
     impl DOMRemove for VElement {
         fn remove(&mut self, parent: &Element) {
-            parent.remove_child(self.dom_ref().unwrap())
-                .expect("Cannot remove non-existent element. But should have existed.");
+            parent.remove_child(&self.dom_ref.take()
+                .expect("Cannot remove non-existent element.")
+            ).unwrap();
         }
     }
 

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -61,43 +61,25 @@ mod wasm {
     use stdweb::web::Node;
 
     impl DOMPatch<VList> for VList {
-        fn patch(&mut self, parent: &Element, old_vnodes: Option<&mut VList>) {
+        fn patch(&mut self, parent: &Element, next: Option<&Node>, old_vnodes: Option<&mut VList>) {
             if let Some(old_vnodes) = old_vnodes {
-                let mut patched_node_keys = vec![];
-                {
-                    for (k, v) in self.children.iter_mut() {
-                        if let Some(pre_vnode) = old_vnodes.children.get_mut(k) {
-                            // Patch if any old VNode found
-                            v.patch(parent, Some(pre_vnode));
-                            patched_node_keys.push(k.clone());
-                        } else {
-                            v.patch(parent, None);
-                        }
+                let mut next_node = None;
+                for (k, v) in self.children.iter_mut().rev() {
+                    if let Some(mut pre_vnode) = old_vnodes.children.swap_remove(k) {
+                        // Patch if any old VNode found
+                        v.patch(parent, next_node.as_ref(), Some(&mut pre_vnode));
+                    } else {
+                        v.patch(parent, next_node.as_ref(), None);
                     }
+                    // should rename it to dom_node()
+                    next_node = v.next_dom_node();
                 }
-                let mut next_key = None;
-                for (k, new_node) in self.children.iter().rev() {
-                    let new_pos = self.position(k);
-                    let old_pos = old_vnodes.position(k);
-                    if new_pos != old_pos {
-                        if let Some(next_key) = next_key {
-                            // This node can be placed before the next one.
-                            let next_vnode = self.children.get(next_key).unwrap();
-                            new_node.move_before(parent, &next_vnode.next_dom_node().unwrap());
-                        } else {
-                            // since there is no node after it, do nothing. as all is alright.
-                        }
-                    }
-                    next_key = Some(k);
-                }
-                for (k, v) in old_vnodes.children.iter_mut() {
-                    if patched_node_keys.iter().position(|it| it == k).is_none() {
-                        v.remove(parent);
-                    }
+                for (_, v) in old_vnodes.children.iter_mut() {
+                    v.remove(parent);
                 }
             } else {
                 for (_, v) in self.children.iter_mut() {
-                    v.patch(parent, None);
+                    v.patch(parent, None, None);
                 }
             }
         }

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -114,7 +114,6 @@ mod wasm {
         for (k, new_node) in new_vnodes.children.iter().rev() {
             let new_pos = new_vnodes.position(k);
             let old_pos = old_vnodes.position(k);
-            console!(log, &format!("k: {}, new_pos: {:?}, old_pos: {:?}", k, new_pos, old_pos));
             if old_pos.is_none() {
                 // It is a new node and already inserted to the write place.
             } else if new_pos.unwrap() != old_pos.unwrap() {

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -84,7 +84,7 @@ mod wasm {
                         if let Some(next_key) = next_key {
                             // This node can be placed before the next one.
                             let next_vnode = self.children.get(next_key).unwrap();
-                            new_node.reorder_before(parent, &next_vnode.next_dom_node().unwrap());
+                            new_node.move_before(parent, &next_vnode.next_dom_node().unwrap());
                         } else {
                             // since there is no node after it, do nothing. as all is alright.
                         }
@@ -113,15 +113,15 @@ mod wasm {
     }
 
     impl DOMReorder for VList {
-        fn reorder_append(&self, parent: &Element) {
+        fn move_to_last(&self, parent: &Element) {
             for (_, v) in self.children.iter() {
-                v.reorder_append(parent);
+                v.move_to_last(parent);
             }
         }
 
-        fn reorder_before(&self, parent: &Element, next: &Node) {
+        fn move_before(&self, parent: &Element, next: &Node) {
             for (_, v) in self.children.iter() {
-                v.reorder_before(parent, next);
+                v.move_before(parent, next);
             }
         }
     }

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -1,8 +1,8 @@
-use CowStr;
-use indexmap::IndexMap;
-use std::fmt::{self, Formatter};
-use std::fmt::Display;
 use vnode::VNode;
+use std::fmt::Display;
+use std::fmt::{Formatter, self};
+use indexmap::IndexMap;
+use CowStr;
 
 type Key = CowStr;
 
@@ -51,16 +51,16 @@ impl From<Vec<VNode>> for VList {
     }
 }
 
-use CowStr;
-use stdweb::web::Element;
-use stdweb::web::Node;
-use super::VList;
-use vdiff::{DOMPatch, DOMRemove};
-use vdiff::DOMReorder;
-use vdiff::NextDOMNode;
-
 #[cfg(target_arch = "wasm32")]
 mod wasm {
+    use super::VList;
+    use vdiff::{DOMPatch, DOMRemove};
+    use stdweb::web::Element;
+    use vdiff::DOMReorder;
+    use vdiff::NextDOMNode;
+    use stdweb::web::Node;
+    use CowStr;
+
     impl DOMPatch<VList> for VList {
         fn patch(&mut self, parent: &Element, _: Option<&Node>, old_vnodes: Option<&mut VList>) {
             if let Some(old_vnodes) = old_vnodes {

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -67,7 +67,6 @@ mod wasm {
                 {
                     for (k, v) in self.children.iter_mut() {
                         if let Some(pre_vnode) = old_vnodes.children.get_mut(k) {
-                            console!(log, &format!("patched: {:?}", v));
                             // Patch if any old VNode found
                             v.patch(parent, Some(pre_vnode));
                             patched_node_keys.push(k.clone());

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -84,7 +84,7 @@ mod wasm {
                         if let Some(next_key) = next_key {
                             // This node can be placed before the next one.
                             let next_vnode = self.children.get(next_key).unwrap();
-                            new_node.insert_before(parent, &next_vnode.next_dom_node().unwrap());
+                            new_node.reorder_before(parent, &next_vnode.next_dom_node().unwrap());
                         } else {
                             // since there is no node after it, do nothing. as all is alright.
                         }
@@ -113,15 +113,15 @@ mod wasm {
     }
 
     impl DOMReorder for VList {
-        fn append_child(&self, parent: &Element) {
+        fn reorder_append(&self, parent: &Element) {
             for (_, v) in self.children.iter() {
-                v.append_child(parent);
+                v.reorder_append(parent);
             }
         }
 
-        fn insert_before(&self, parent: &Element, next: &Node) {
+        fn reorder_before(&self, parent: &Element, next: &Node) {
             for (_, v) in self.children.iter() {
-                v.insert_before(parent, next);
+                v.reorder_before(parent, next);
             }
         }
     }

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -17,6 +17,10 @@ impl VList {
             children
         }
     }
+
+    fn position(&self, key: &str) -> Option<usize> {
+        self.children.iter().position(|(k, _)| k == key)
+    }
 }
 
 impl Display for VList {
@@ -50,28 +54,42 @@ impl From<Vec<VNode>> for VList {
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use super::VList;
-    use vdiff::{DOMPatch, DOMRemove, DOMReorder};
+    use vdiff::{DOMPatch, DOMRemove};
     use stdweb::web::Element;
     use indexmap::IndexMap;
+    use stdweb::web::INode;
+    use vdiff::DOMReorder;
 
     impl DOMPatch<VList> for VList {
-        fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VList>) {
-            if let Some(old_vnode) = old_vnode {
-                let mut old_children: IndexMap<_, _> = old_vnode.children.iter_mut().collect();
-                for (k, v) in self.children.iter_mut() {
-                    if let Some(pre_vnode) = old_children.swap_remove(k) {
-                        // Patch if any old VNode found
-                        v.patch(parent, Some(pre_vnode));
-                        // Reorder based on insertion
-                        v.reorder(parent);
-                    } else {
-                        v.patch(parent, None);
+        fn patch(&mut self, parent: &Element, old_vnodes: Option<&mut VList>) {
+            if let Some(old_vnodes) = old_vnodes {
+                let mut added_node_keys = vec![];
+                let mut patched_node_keys = vec![];
+                {
+                    for (k, v) in self.children.iter_mut() {
+                        if let Some(pre_vnode) = old_vnodes.children.get_mut(k) {
+                            // Patch if any old VNode found
+                            v.patch(parent, Some(pre_vnode));
+                            patched_node_keys.push(k.clone());
+                        } else {
+                            added_node_keys.push(k.clone());
+//                            v.patch(parent, None);
+                        }
                     }
+                    // Remove any VNodes left out
+//                    for (_, v) in old_children {
+//                        v.remove(parent);
+//                    }
                 }
-                // Remove any VNodes left out
-                for (_, v) in old_children {
-                    v.remove(parent);
-                }
+//                let mut reorder_forced = false;
+//                for (k, v) in self.children.iter() {
+//                    if reorder_forced || self.position(k) != old_vnodes.position(k) {
+//                        v.reorder(parent);
+//                        if !reorder_forced {
+//                            reorder_forced = true;
+//                        }
+//                    }
+//                }
             } else {
                 for (_, v) in self.children.iter_mut() {
                     v.patch(parent, None);
@@ -89,9 +107,15 @@ mod wasm {
     }
 
     impl DOMReorder for VList {
-        fn reorder(&self, parent: &Element) {
+        fn append_child(&self, parent: &Element) {
             for (_, v) in self.children.iter() {
-                v.reorder(parent);
+                v.append_child(parent);
+            }
+        }
+
+        fn insert_before<T: INode>(&self, parent: &Element, next: &T) {
+            for (_, v) in self.children.iter() {
+                v.insert_before(parent, next);
             }
         }
     }

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -62,11 +62,11 @@ mod wasm {
     use CowStr;
 
     impl DOMPatch<VList> for VList {
-        fn patch(&mut self, parent: &Element, _: Option<&Node>, old_vnodes: Option<&mut VList>) {
+        fn patch(&mut self, parent: &Element, next: Option<&Node>, old_vnodes: Option<&mut VList>) {
             if let Some(old_vnodes) = old_vnodes {
                 let mut patched_node_keys = vec![];
                 {
-                    let mut next_node = None;
+                    let mut next_node = next.map(|it| it.clone());
                     for (k, v) in self.children.iter_mut().rev() {
                         if let Some(pre_vnode) = old_vnodes.children.get_mut(k) {
                             // Patch if any old VNode found
@@ -114,15 +114,15 @@ mod wasm {
         for (k, new_node) in new_vnodes.children.iter().rev() {
             let new_pos = new_vnodes.position(k);
             let old_pos = old_vnodes.position(k);
+            console!(log, &format!("k: {}, new_pos: {:?}, old_pos: {:?}", k, new_pos, old_pos));
             if old_pos.is_none() {
                 // It is a new node and already inserted to the write place.
             } else if new_pos.unwrap() != old_pos.unwrap() {
                 if let Some(next_key) = next_key {
-                    // This node can be placed before the next one.
                     let next_vnode = new_vnodes.children.get(next_key).unwrap();
                     new_node.move_before(parent, &next_vnode.next_dom_node().unwrap());
                 } else {
-                    // since there is no node after it, do nothing. as all is alright.
+                    new_node.move_to_last(parent);
                 }
             }
             next_key = Some(k);

--- a/papito_dom/src/vlist.rs
+++ b/papito_dom/src/vlist.rs
@@ -55,9 +55,9 @@ mod wasm {
     use indexmap::IndexMap;
 
     impl DOMPatch<VList> for VList {
-        fn patch(&mut self, parent: &Element, old_vnode: Option<&VList>) {
-            if let Some(ref old_vnode) = old_vnode {
-                let mut old_children: IndexMap<_, _> = old_vnode.children.iter().collect();
+        fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VList>) {
+            if let Some(old_vnode) = old_vnode {
+                let mut old_children: IndexMap<_, _> = old_vnode.children.iter_mut().collect();
                 for (k, v) in self.children.iter_mut() {
                     if let Some(pre_vnode) = old_children.swap_remove(k) {
                         // Patch if any old VNode found
@@ -81,8 +81,8 @@ mod wasm {
     }
 
     impl DOMRemove for VList {
-        fn remove(&self, parent: &Element) {
-            for (_, child) in self.children.iter() {
+        fn remove(&mut self, parent: &Element) {
+            for (_, child) in self.children.iter_mut() {
                 child.remove(parent);
             }
         }

--- a/papito_dom/src/vnode.rs
+++ b/papito_dom/src/vnode.rs
@@ -84,19 +84,19 @@ mod wasm {
     }
 
     impl DOMReorder for VNode {
-        fn reorder_append(&self, parent: &Element) {
+        fn move_to_last(&self, parent: &Element) {
             match *self {
-                VNode::Text(ref text) => text.reorder_append(parent),
-                VNode::Element(ref element) => element.reorder_append(parent),
-                VNode::List(ref list) => list.reorder_append(parent)
+                VNode::Text(ref text) => text.move_to_last(parent),
+                VNode::Element(ref element) => element.move_to_last(parent),
+                VNode::List(ref list) => list.move_to_last(parent)
             }
         }
 
-        fn reorder_before(&self, parent: &Element, next: &Node) {
+        fn move_before(&self, parent: &Element, next: &Node) {
             match *self {
-                VNode::Text(ref text) => text.reorder_before(parent, next),
-                VNode::Element(ref element) => element.reorder_before(parent, next),
-                VNode::List(ref list) => list.reorder_before(parent, next)
+                VNode::Text(ref text) => text.move_before(parent, next),
+                VNode::Element(ref element) => element.move_before(parent, next),
+                VNode::List(ref list) => list.move_before(parent, next)
             }
         }
     }

--- a/papito_dom/src/vnode.rs
+++ b/papito_dom/src/vnode.rs
@@ -52,7 +52,7 @@ mod wasm {
             match *$against {
                 $(
                     VNode::$variant(ref mut node_like) => {
-                        if let Some(&VNode::$variant(ref old_node_like)) = $old_vnode {
+                        if let Some(&mut VNode::$variant(ref mut old_node_like)) = $old_vnode {
                             node_like.patch($parent, Some(old_node_like));
                         } else {
                             $old_vnode.remove($parent);
@@ -65,17 +65,17 @@ mod wasm {
     }
 
     impl DOMPatch<VNode> for VNode {
-        fn patch(&mut self, parent: &Element, old_vnode: Option<&VNode>) {
+        fn patch(&mut self, parent: &Element, mut old_vnode: Option<&mut VNode>) {
             match_for_vnode_patch!(self, parent, old_vnode, [Text, Element, List]);
         }
     }
 
     impl DOMRemove for VNode {
-        fn remove(&self, parent: &Element) {
+        fn remove(&mut self, parent: &Element) {
             match *self {
-                VNode::Text(ref text) => text.remove(parent),
-                VNode::Element(ref element) => element.remove(parent),
-                VNode::List(ref list) => list.remove(parent)
+                VNode::Text(ref mut text) => text.remove(parent),
+                VNode::Element(ref mut element) => element.remove(parent),
+                VNode::List(ref mut list) => list.remove(parent)
             }
         }
     }

--- a/papito_dom/src/vnode.rs
+++ b/papito_dom/src/vnode.rs
@@ -51,15 +51,15 @@ mod wasm {
     use stdweb::web::Node;
 
     macro_rules! match_for_vnode_patch {
-        ($against:ident, $parent:ident, $old_vnode:ident, [$( $variant:ident ),*] ) => {
+        ($against:ident, $parent:ident, $next:ident, $old_vnode:ident, [$( $variant:ident ),*] ) => {
             match *$against {
                 $(
                     VNode::$variant(ref mut node_like) => {
                         if let Some(&mut VNode::$variant(ref mut old_node_like)) = $old_vnode {
-                            node_like.patch($parent, Some(old_node_like));
+                            node_like.patch($parent, $next, Some(old_node_like));
                         } else {
                             $old_vnode.remove($parent);
-                            node_like.patch($parent, None);
+                            node_like.patch($parent, $next, None);
                         }
                     }
                 )*
@@ -68,8 +68,8 @@ mod wasm {
     }
 
     impl DOMPatch<VNode> for VNode {
-        fn patch(&mut self, parent: &Element, mut old_vnode: Option<&mut VNode>) {
-            match_for_vnode_patch!(self, parent, old_vnode, [Text, Element, List]);
+        fn patch(&mut self, parent: &Element, next: Option<&Node>, mut old_vnode: Option<&mut VNode>) {
+            match_for_vnode_patch!(self, parent, next, old_vnode, [Text, Element, List]);
         }
     }
 

--- a/papito_dom/src/vnode.rs
+++ b/papito_dom/src/vnode.rs
@@ -43,9 +43,11 @@ impl_conversion_to_vnode!(List, VList);
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use vdiff::{DOMPatch, DOMRemove, DOMReorder};
+    use vdiff::{DOMPatch, DOMRemove};
     use stdweb::web::Element;
     use super::VNode;
+    use stdweb::web::INode;
+    use vdiff::DOMReorder;
 
     macro_rules! match_for_vnode_patch {
         ($against:ident, $parent:ident, $old_vnode:ident, [$( $variant:ident ),*] ) => {
@@ -81,11 +83,19 @@ mod wasm {
     }
 
     impl DOMReorder for VNode {
-        fn reorder(&self, parent: &Element) {
+        fn append_child(&self, parent: &Element) {
             match *self {
-                VNode::Text(ref text) => text.reorder(parent),
-                VNode::Element(ref element) => element.reorder(parent),
-                VNode::List(ref list) => list.reorder(parent)
+                VNode::Text(ref text) => text.append_child(parent),
+                VNode::Element(ref element) => element.append_child(parent),
+                VNode::List(ref list) => list.append_child(parent)
+            }
+        }
+
+        fn insert_before<T: INode>(&self, parent: &Element, next: &T) {
+            match *self {
+                VNode::Text(ref text) => text.insert_before(parent, next),
+                VNode::Element(ref element) => element.insert_before(parent, next),
+                VNode::List(ref list) => list.insert_before(parent, next)
             }
         }
     }

--- a/papito_dom/src/vnode.rs
+++ b/papito_dom/src/vnode.rs
@@ -46,8 +46,9 @@ mod wasm {
     use vdiff::{DOMPatch, DOMRemove};
     use stdweb::web::Element;
     use super::VNode;
-    use stdweb::web::INode;
     use vdiff::DOMReorder;
+    use vdiff::NextDOMNode;
+    use stdweb::web::Node;
 
     macro_rules! match_for_vnode_patch {
         ($against:ident, $parent:ident, $old_vnode:ident, [$( $variant:ident ),*] ) => {
@@ -91,11 +92,21 @@ mod wasm {
             }
         }
 
-        fn insert_before<T: INode>(&self, parent: &Element, next: &T) {
+        fn insert_before(&self, parent: &Element, next: &Node) {
             match *self {
                 VNode::Text(ref text) => text.insert_before(parent, next),
                 VNode::Element(ref element) => element.insert_before(parent, next),
                 VNode::List(ref list) => list.insert_before(parent, next)
+            }
+        }
+    }
+
+    impl NextDOMNode for VNode {
+        fn next_dom_node(&self) -> Option<Node> {
+            match *self {
+                VNode::Text(ref text) => text.next_dom_node(),
+                VNode::Element(ref element) => element.next_dom_node(),
+                VNode::List(ref list) => list.next_dom_node()
             }
         }
     }

--- a/papito_dom/src/vnode.rs
+++ b/papito_dom/src/vnode.rs
@@ -84,19 +84,19 @@ mod wasm {
     }
 
     impl DOMReorder for VNode {
-        fn append_child(&self, parent: &Element) {
+        fn reorder_append(&self, parent: &Element) {
             match *self {
-                VNode::Text(ref text) => text.append_child(parent),
-                VNode::Element(ref element) => element.append_child(parent),
-                VNode::List(ref list) => list.append_child(parent)
+                VNode::Text(ref text) => text.reorder_append(parent),
+                VNode::Element(ref element) => element.reorder_append(parent),
+                VNode::List(ref list) => list.reorder_append(parent)
             }
         }
 
-        fn insert_before(&self, parent: &Element, next: &Node) {
+        fn reorder_before(&self, parent: &Element, next: &Node) {
             match *self {
-                VNode::Text(ref text) => text.insert_before(parent, next),
-                VNode::Element(ref element) => element.insert_before(parent, next),
-                VNode::List(ref list) => list.insert_before(parent, next)
+                VNode::Text(ref text) => text.reorder_before(parent, next),
+                VNode::Element(ref element) => element.reorder_before(parent, next),
+                VNode::List(ref list) => list.reorder_before(parent, next)
             }
         }
     }

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -48,7 +48,9 @@ mod wasm {
         fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VText>) {
             if let Some(old_vnode) = old_vnode {
                 let text_node = old_vnode.dom_ref().unwrap().clone();
-                text_node.set_text_content(&self.content);
+                if old_vnode.content != self.content {
+                    text_node.set_text_content(&self.content);
+                }
                 self.dom_ref = Some(text_node);
             } else {
                 let text_node = document().create_text_node(&self.content);

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -41,8 +41,10 @@ impl<T: Into<CowStr>> From<T> for VText {
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use stdweb::web::{Element, document, INode};
-    use vdiff::{DOMPatch, DOMReorder, DOMRemove};
+    use vdiff::{DOMPatch, DOMRemove};
     use super::VText;
+    use stdweb::web::TextNode;
+    use vdiff::DOMReorder;
 
     impl DOMPatch<VText> for VText {
         fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VText>) {
@@ -61,9 +63,14 @@ mod wasm {
     }
 
     impl DOMReorder for VText {
-        fn reorder(&self, parent: &Element) {
-            let dom_ref = self.dom_ref().expect("Cannot re-order previously non-existent text node.");
+        fn append_child(&self, parent: &Element) {
+            let dom_ref = self.dom_ref().expect("Cannot append previously non-existent text node.");
             parent.append_child(dom_ref);
+        }
+
+        fn insert_before<T: INode>(&self, parent: &Element, next: &T) {
+            parent.insert_before(self.dom_ref().expect("Cannot insert previously non-existent text node."), next)
+                .unwrap();
         }
     }
 

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -45,7 +45,7 @@ mod wasm {
     use super::VText;
 
     impl DOMPatch<VText> for VText {
-        fn patch(&mut self, parent: &Element, old_vnode: Option<&VText>) {
+        fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VText>) {
             if let Some(old_vnode) = old_vnode {
                 let text_node = old_vnode.dom_ref().unwrap().clone();
                 text_node.set_text_content(&self.content);
@@ -66,7 +66,7 @@ mod wasm {
     }
 
     impl DOMRemove for VText {
-        fn remove(&self, parent: &Element) {
+        fn remove(&mut self, parent: &Element) {
             parent.remove_child(self.dom_ref().unwrap())
                 .expect("Cannot remove non-existent text node. But should have existed.");
         }

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -64,12 +64,12 @@ mod wasm {
     }
 
     impl DOMReorder for VText {
-        fn reorder_append(&self, parent: &Element) {
+        fn move_to_last(&self, parent: &Element) {
             let dom_ref = self.dom_ref().expect("Cannot append previously non-existent text node.");
             parent.append_child(dom_ref);
         }
 
-        fn reorder_before(&self, parent: &Element, next: &Node) {
+        fn move_before(&self, parent: &Element, next: &Node) {
             parent.insert_before(self.dom_ref().expect("Cannot insert previously non-existent text node."), next)
                 .unwrap();
         }

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -48,7 +48,7 @@ mod wasm {
     use stdweb::web::Node;
 
     impl DOMPatch<VText> for VText {
-        fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VText>) {
+        fn patch(&mut self, parent: &Element, next: Option<&Node>, old_vnode: Option<&mut VText>) {
             if let Some(old_vnode) = old_vnode {
                 let text_node = old_vnode.dom_ref().unwrap().clone();
                 if old_vnode.content != self.content {
@@ -58,7 +58,11 @@ mod wasm {
             } else {
                 let text_node = document().create_text_node(&self.content);
                 self.dom_ref = Some(text_node);
-                parent.append_child(self.dom_ref().unwrap());
+                if let Some(next) = next {
+                    parent.insert_before(self.dom_ref().unwrap(), next);
+                } else {
+                    parent.append_child(self.dom_ref().unwrap());
+                }
             }
         }
     }

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -59,7 +59,7 @@ mod wasm {
                 let text_node = document().create_text_node(&self.content);
                 self.dom_ref = Some(text_node);
                 if let Some(next) = next {
-                    parent.insert_before(self.dom_ref().unwrap(), next);
+                    parent.insert_before(self.dom_ref().unwrap(), next).unwrap();
                 } else {
                     parent.append_child(self.dom_ref().unwrap());
                 }

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -67,8 +67,9 @@ mod wasm {
 
     impl DOMRemove for VText {
         fn remove(&mut self, parent: &Element) {
-            parent.remove_child(self.dom_ref().unwrap())
-                .expect("Cannot remove non-existent text node. But should have existed.");
+            parent.remove_child(&self.dom_ref.take()
+                .expect("Cannot remove non-existent text node.")
+            ).unwrap();
         }
     }
 }

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -64,12 +64,12 @@ mod wasm {
     }
 
     impl DOMReorder for VText {
-        fn append_child(&self, parent: &Element) {
+        fn reorder_append(&self, parent: &Element) {
             let dom_ref = self.dom_ref().expect("Cannot append previously non-existent text node.");
             parent.append_child(dom_ref);
         }
 
-        fn insert_before(&self, parent: &Element, next: &Node) {
+        fn reorder_before(&self, parent: &Element, next: &Node) {
             parent.insert_before(self.dom_ref().expect("Cannot insert previously non-existent text node."), next)
                 .unwrap();
         }

--- a/papito_dom/src/vtext.rs
+++ b/papito_dom/src/vtext.rs
@@ -43,8 +43,9 @@ mod wasm {
     use stdweb::web::{Element, document, INode};
     use vdiff::{DOMPatch, DOMRemove};
     use super::VText;
-    use stdweb::web::TextNode;
     use vdiff::DOMReorder;
+    use vdiff::NextDOMNode;
+    use stdweb::web::Node;
 
     impl DOMPatch<VText> for VText {
         fn patch(&mut self, parent: &Element, old_vnode: Option<&mut VText>) {
@@ -68,7 +69,7 @@ mod wasm {
             parent.append_child(dom_ref);
         }
 
-        fn insert_before<T: INode>(&self, parent: &Element, next: &T) {
+        fn insert_before(&self, parent: &Element, next: &Node) {
             parent.insert_before(self.dom_ref().expect("Cannot insert previously non-existent text node."), next)
                 .unwrap();
         }
@@ -79,6 +80,12 @@ mod wasm {
             parent.remove_child(&self.dom_ref.take()
                 .expect("Cannot remove non-existent text node.")
             ).unwrap();
+        }
+    }
+
+    impl NextDOMNode for VText {
+        fn next_dom_node(&self) -> Option<Node> {
+            self.dom_ref.clone().map(|it| it.into())
         }
     }
 }


### PR DESCRIPTION
To remove event listeners from older nodes, made them mutable. Also along the way studied what Vue patches on update and tried to replicate the same effect. So, now its as efficient as I could get.